### PR TITLE
Update browser-history to v0.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiodns==2.0.0
 aiohttp==3.6.3
 async-timeout==3.0.1
 attrs==20.2.0
-browser-history==0.2.1
+browser-history==0.3.0
 certifi==2020.6.20
 cffi==1.14.3
 chardet==3.0.4

--- a/src/Entities/History.py
+++ b/src/Entities/History.py
@@ -11,7 +11,7 @@ class History(object):
 
     def __get_entries(self, max_length):
         history = get_history()
-        history_entries = history.entries
+        history_entries = history.histories
         history_entries.reverse()
         self.entries = []
         if max_length is not None:


### PR DESCRIPTION
Hi,

I'm the maintainer of [`browser-history`](https://github.com/pesos/browser-history). We recently released [v0.3.0](https://github.com/pesos/browser-history/releases/tag/v0.3.0) with many fixes and new features.

I have updated the version of browser-history in your repo and made corresponding changes that were required due to the changed API.

I have tested it, but not thoroughly.